### PR TITLE
sets VALGRIND_OPTS to enable --leak-check=full by default

### DIFF
--- a/ide50/files/etc/profile.d/ide50.sh
+++ b/ide50/files/etc/profile.d/ide50.sh
@@ -53,6 +53,9 @@ alias python=python3
 alias pip=pip3
 export PYTHONDONTWRITEBYTECODE=1
 
+# valgrind defaults
+export VALGRIND_OPTS=--memcheck:leak-check=full
+
 # set editor
 export EDITOR=nano
 


### PR DESCRIPTION
Per http://valgrind.org/docs/manual/manual-core.html#manual-core.defopts.

CC @kzidane @brianyu28 