### PR TITLE
enables alias expansion with sudo

### DIFF
--- a/ide50/debian/changelog
+++ b/ide50/debian/changelog
@@ -1,3 +1,9 @@
+ide50 (94) 2015; urgency=medium
+
+  * enables alias expansion with sudo
+
+ -- CS50 <sysadmins@cs50.harvard.edu>  Sun, 6 Nov 2016 11:25:00 -0400
+
 ide50 (93) 2015; urgency=medium
 
   * update dependences of lib50-python and phpliteadmin

--- a/ide50/files/etc/profile.d/ide50.sh
+++ b/ide50/files/etc/profile.d/ide50.sh
@@ -65,6 +65,9 @@ export PYTHONDONTWRITEBYTECODE=1
 # sqlite3
 alias sqlite3="sqlite3 -column -header"
 
+# sudo
+alias sudo="sudo "
+
 # flask
 export FLASK_APP=application.py
 export FLASK_DEBUG=1

--- a/ide50/files/etc/profile.d/ide50.sh
+++ b/ide50/files/etc/profile.d/ide50.sh
@@ -66,6 +66,7 @@ export PYTHONDONTWRITEBYTECODE=1
 alias sqlite3="sqlite3 -column -header"
 
 # sudo
+# trailing space enables elevated command to be an alias
 alias sudo="sudo "
 
 # flask

--- a/ide50/files/etc/version50
+++ b/ide50/files/etc/version50
@@ -1,1 +1,1 @@
-version=93
+version=94


### PR DESCRIPTION
Turns out aliases aren't expanded when using `sudo` by default. This aliases `sudo` to `"sudo "` as per bash [manual](http://www.gnu.org/software/bash/manual/bashref.html#Aliases) 

> If the last character of the alias value is a blank, then the next command word following the alias is also checked for alias expansion.

cc @dmalan @glennholloway 