### PR TITLE
moves permission-setting to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ deb: clean Makefile
 
 	@echo "\nBuilding Deb..."
 	echo "version=$(VERSION)" > "$(VERSION_FILE)"
+
+	# set permissions
+	chmod -R 755 "$(FILES_DIR)/usr/bin/"
+	chmod 644 "$(VERSION_FILE)" "$(FILES_DIR)/etc/profile.d/ide50.sh" "$(FILES_DIR)/home/ubuntu/.prompt50"
+
 	fpm \
 	-C "$(FILES_DIR)" \
 	--after-install postinst \

--- a/postinst
+++ b/postinst
@@ -7,24 +7,10 @@ chmod -R g+w /home/ubuntu/workspace
 chown -R ubuntu:ubuntu /var/c9sdk/plugins/c9.ide.cs50* >/dev/null 2>&1
 chown -R ubuntu:ubuntu /var/c9sdk/configs/ >/dev/null 2>&1
 
-chmod 755 /usr/bin/apache50
-chmod 755 /usr/bin/backup50
-chmod 755 /usr/bin/decomment50
-chmod 755 /usr/bin/hostname50
-chmod 755 /usr/bin/mysql50
-chmod 755 /usr/bin/password50
-chmod 755 /usr/bin/update50
-chmod 755 /usr/bin/username50
-chmod 755 /usr/bin/version50
-
 if [ -e /home/ubuntu/bin/debug50 ]; then
     chown ubuntu:ubuntu /home/ubuntu/bin/debug50
     chmod a+rx,g+w /home/ubuntu/bin/debug50
 fi
-
-echo "Setting configuration files ..."
-chmod 644 /etc/version50
-chmod 644 /etc/profile.d/ide50.sh
 
 # remove dropbox functions
 sed -i 's:source /home/ubuntu/.dropbox50::g' ~/.bashrc
@@ -117,10 +103,6 @@ if ! grep -qs "alias cd" /home/ubuntu/.bashrc; then
     echo 'alias cd="HOME=~/workspace cd"' >>/home/ubuntu/.bashrc
 fi
 
-# use our prompt
-if [ -f /home/ubuntu/.prompt50 ]; then
-    chmod a+r /home/ubuntu/.prompt50
-fi
 if ! grep -qs 'prompt50' /home/ubuntu/.bashrc; then
     echo "source /home/ubuntu/.prompt50" >>/home/ubuntu/.bashrc
 fi


### PR DESCRIPTION
@glennholloway, fpm [preserves](https://github.com/cs50/lib50-c/pull/19#r73718371) permission settings. Might be better to have them in the makefile before packaging? Fewer lines, easier to reference, and should catch chmod errors (if any) a little earlier?