### PR TITLE
Conflicts/config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ deb: clean Makefile
 		php5-curl, \
 		php5-sqlite, \
 		php5-xdebug, \
-		phpliteadmin (>= 1.1.1), \
+		phpliteadmin (>= 1.2.2), \
 		python3-pip, \
 		python3-tk, \
 		render50, \

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ deb: clean Makefile
 	-C "$(FILES_DIR)" \
 	--after-install postinst \
 	--category misc \
+	--conflicts lib50-python \
+	--conflicts submit50 \
 	--deb-changelog changelog \
 	--deb-no-default-config-files \
 	--deb-priority optional \
@@ -69,13 +71,11 @@ deb: clean Makefile
 		php5-sqlite, \
 		php5-xdebug, \
 		phpliteadmin (>= 1.1.1), \
-		python-cs50 (>= 1.2.4), \
 		python3-pip, \
 		python3-tk, \
 		render50, \
 		sqlite3, \
 		style50, \
-		submit50 (>= 2.1.4), \
 		telnet, \
 		traceroute, \
 		wamerican, \

--- a/changelog
+++ b/changelog
@@ -4,6 +4,8 @@ ide50 (99) 2015; urgency=medium
   * installs cs50 python library and submit50 via pip
   * drops server50 dependency
   * ensures pip doesn't fail silently
+  * removes dropbox alias
+  * fixes rvm issue for help50
 
  -- CS50 <sysadmins@cs50.harvard.edu>  Sun, 16 Feb 2017 8:00:00 -0400
 

--- a/changelog
+++ b/changelog
@@ -1,8 +1,9 @@
 ide50 (99) 2015; urgency=medium
 
   * updates configs' paths and filenames for offline IDE
-  * updates lib50-python's name
+  * installs cs50 python library and submit50 via pip
   * drops server50 dependency
+  * ensures pip doesn't fail silently
 
  -- CS50 <sysadmins@cs50.harvard.edu>  Sun, 16 Feb 2017 8:00:00 -0400
 

--- a/postinst
+++ b/postinst
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# suppress CS50 compilation preferences
+unset CC CFLAGS LDLIBS
+
 echo "Resetting permissions ..."
 
 chmod -R g+w /home/ubuntu/workspace
@@ -115,12 +118,9 @@ fi
 # create a password50 file, if it doesn't exist
 sudo -Eu ubuntu /usr/bin/password50 >/dev/null 2>&1
 
-# install python packages, suppressing CS50 compilation preferences
+# install python packages
 PYTHON_PACKAGES="cs50>=1.2.4 Flask Flask-SQLAlchemy Flask-Session SQLAlchemy submit50>=2.1.5"
-(
-unset CC CFLAGS LDLIBS
-pip3 install $PYTHON_PACKAGES
-)
+( pip3 install $PYTHON_PACKAGES )
 
 
 # add mysql username and password to env

--- a/postinst
+++ b/postinst
@@ -170,9 +170,6 @@ if [ ${IDE_OFFLINE+x} ]; then
     pushd /var/c9sdk >/dev/null 2>&1
     sudo -Eu ubuntu scripts/install-sdk.sh >/dev/null 2>&1
     popd >/dev/null 2>&1
-    echo
-    echo "All done! <3"
-    echo "PLEASE RELOAD YOUR WORKSPACE TO GET THE LATEST UPDATES! <3"
 else
     # plugin updates aren't necessary for online IDEs; remove files
     rm -rf /var/c9sdk/plugins/c9.ide.cs50* >/dev/null 2>&1
@@ -181,9 +178,8 @@ else
     rm -rf /var/c9sdk/configs/client-workspace-cs50.js >/dev/null 2>&1
     rm -rf /var/c9sdk/configs/ide/workspace-cs50.js >/dev/null 2>&1
     rmdir -p /var/c9sdk/configs/ide >/dev/null 2>&1
-
-    echo
-    echo "All done! <3"
 fi
+
+echo -e "\nAll done! <3"
 
 exit 0

--- a/postinst
+++ b/postinst
@@ -119,7 +119,7 @@ fi
 sudo -Eu ubuntu /usr/bin/password50 >/dev/null 2>&1
 
 # install python packages
-PYTHON_PACKAGES="cs50>=1.2.4 Flask Flask-SQLAlchemy Flask-Session SQLAlchemy submit50>=2.1.5"
+PYTHON_PACKAGES="cs50>=1.3.0 Flask Flask-SQLAlchemy Flask-Session SQLAlchemy submit50>=2.2.0"
 ( pip3 install $PYTHON_PACKAGES )
 
 

--- a/postinst
+++ b/postinst
@@ -115,10 +115,12 @@ fi
 # create a password50 file, if it doesn't exist
 sudo -Eu ubuntu /usr/bin/password50 >/dev/null 2>&1
 
+PYTHON_PACKAGES="cs50>=1.2.4 Flask Flask-SQLAlchemy Flask-Session SQLAlchemy submit50>=2.1.5"
+
 # install Flask and SQLAlchemy, suppressing CS50 compilation preferences
 if [ -x /usr/bin/pip3 ]; then
     ( unset CC CFLAGS LDLIBS
-      /usr/bin/pip3 install Flask Flask-SQLAlchemy Flask-Session SQLAlchemy >/dev/null 2>&1
+      /usr/bin/pip3 install $PYTHON_PACKAGES >/dev/null 2>&1
     )
 fi
 
@@ -168,7 +170,7 @@ if [ ${IDE_OFFLINE+x} ]; then
     popd >/dev/null 2>&1
     echo
     echo "All done! <3"
-    echo "Please reload your workspace to get the latest updates!"
+    echo "PLEASE RELOAD YOUR WORKSPACE TO GET THE LATEST UPDATES! <3"
 else
     # plugin updates aren't necessary for online IDEs; remove files
     rm -rf /var/c9sdk/plugins/c9.ide.cs50* >/dev/null 2>&1

--- a/postinst
+++ b/postinst
@@ -115,14 +115,13 @@ fi
 # create a password50 file, if it doesn't exist
 sudo -Eu ubuntu /usr/bin/password50 >/dev/null 2>&1
 
+# install python packages, suppressing CS50 compilation preferences
 PYTHON_PACKAGES="cs50>=1.2.4 Flask Flask-SQLAlchemy Flask-Session SQLAlchemy submit50>=2.1.5"
+(
+unset CC CFLAGS LDLIBS
+pip3 install $PYTHON_PACKAGES
+)
 
-# install Flask and SQLAlchemy, suppressing CS50 compilation preferences
-if [ -x /usr/bin/pip3 ]; then
-    ( unset CC CFLAGS LDLIBS
-      /usr/bin/pip3 install $PYTHON_PACKAGES >/dev/null 2>&1
-    )
-fi
 
 # add mysql username and password to env
 sudo cat >/etc/profile.d/mysql.sh <<EOF

--- a/postinst
+++ b/postinst
@@ -163,6 +163,9 @@ if [ ${IDE_OFFLINE+x} ]; then
         echo -e "\nalias c9=/var/c9sdk/bin/c9" >>/etc/profile.d/offline.sh
     fi
 
+    # remove old config file
+    rm -rf /var/c9sdk/configs/client-workspace-cs50.js
+
     # offline only: update c9sdk and plugins
     echo "Updating Cloud9 SDK ..."
     pushd /var/c9sdk >/dev/null 2>&1


### PR DESCRIPTION
This just removes `lib50-python` and `submit50` debs, if installed, and installs them back via `pip`. It also ensures the old config file is removed from offline workspaces to prevent it from overwriting the new one.

cc @dmalan @glennholloway 