### PR TITLE
unquoted some env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION_FILE := $(FILES_DIR)/etc/version50
 PLUGINS := audioplayer cat debug gist hex info presentation simple theme
 
 NAME := ide50
-VERSION := 104
+VERSION := 105
 
 define getplugin
 	@echo "\nFetching $(1)..."

--- a/files/etc/profile.d/ide50.sh
+++ b/files/etc/profile.d/ide50.sh
@@ -134,7 +134,7 @@ flask()
         done
 
         # spawn flask
-        script --flush --quiet --return /dev/null --command 'FLASK_APP="$FLASK_APP" FLASK_DEBUG="$FLASK_DEBUG" flask run $host $port $threads $options' |
+        script --flush --quiet --return /dev/null --command "FLASK_APP=\"$FLASK_APP\" FLASK_DEBUG=\"$FLASK_DEBUG\" flask run $host $port $threads $options" |
             while IFS= read -r line
             do
                 # rewrite address as $C9_HOSTNAME
@@ -187,7 +187,7 @@ http_server()
     done
 
     # spawn http-server, retaining colorized output
-    script --flush --quiet --return /dev/null --command 'http-server "$a" "$c" "$cors" "$i" "$p" "$options"' |
+    script --flush --quiet --return /dev/null --command "http-server $a $c $cors $i $p $options" |
         while IFS= read -r line
         do
             # rewrite address as $C9_HOSTNAME


### PR DESCRIPTION
I don't think we should quote these env vars because:

1. we're already quoting them when we initialize them or update their values
1. `flask` doesn't like empty arguments for example
 ```
 $ flask run ""
 Usage: flask run [OPTIONS]

 Error: Got unexpected extra argument ()
 ```
1. some of them are not really a single argument (e.g., `$a` for `http-server`)

Once approved I'll roll out v105 immediately to fix the flask issue.