### PR TITLE
python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION_FILE := $(FILES_DIR)/etc/version50
 PLUGINS := audioplayer cat debug gist hex info presentation simple theme
 
 NAME := ide50
-VERSION := 107
+VERSION := 108
 
 define getplugin
 	@echo "\nFetching $(1)..."

--- a/files/etc/profile.d/ide50.sh
+++ b/files/etc/profile.d/ide50.sh
@@ -74,9 +74,11 @@ export TMOUT="0"
 export CLASSPATH=".:/usr/share/java/cs50.jar"
 
 # python3
-alias pip="pip3"
+alias pip="pip3.6"
+alias pip3="pip3.6"
 alias pylint="pylint3"
-alias python="python3"
+alias python="python3.6"
+alias python3="python3.6"
 export PYTHONDONTWRITEBYTECODE="1"
 
 # unset so user doesn't have to restart IDE

--- a/update50
+++ b/update50
@@ -153,7 +153,7 @@ PYTHON_PACKAGES="check50==2.0.1 \
     termcolor \
     twython \
     virtualenv"
-( /usr/bin/sudo pip3 install $PYTHON_PACKAGES )
+( /usr/bin/sudo pip3.6 install $PYTHON_PACKAGES )
 
 echo "Update complete!"
 echo -e "\nBE SURE TO CLOSE AND RE-OPEN ANY TERMINAL WINDOWS <3\n"

--- a/update50
+++ b/update50
@@ -110,7 +110,6 @@ fi
 
 echo "FYI: installing Python may take a while. Thank you for your patience! <3"
 /opt/pyenv/bin/pyenv install --skip-existing 3.6.0
-/opt/pyenv/bin/pyenv rehash
 /opt/pyenv/bin/pyenv global system 3.6.0
 
 echo "Removing unneeded packages..."
@@ -154,6 +153,8 @@ PYTHON_PACKAGES="check50==2.0.1 \
     twython \
     virtualenv"
 ( /usr/bin/sudo pip3.6 install $PYTHON_PACKAGES )
+
+/opt/pyenv/bin/pyenv rehash
 
 echo "Update complete!"
 echo -e "\nBE SURE TO CLOSE AND RE-OPEN ANY TERMINAL WINDOWS <3\n"

--- a/update50
+++ b/update50
@@ -111,7 +111,7 @@ fi
 echo "FYI: installing Python may take a while. Thank you for your patience! <3"
 /opt/pyenv/bin/pyenv install --skip-existing 3.6.0
 /opt/pyenv/bin/pyenv rehash
-/opt/pyenv/bin/pyenv global 3.6.0
+/opt/pyenv/bin/pyenv global system 3.6.0
 
 echo "Removing unneeded packages..."
 /usr/bin/sudo apt-get autoremove -y


### PR DESCRIPTION
Should resolve Cloud9's Python problem and use the default Python 2.7 per our emails.

```
$ python --version
Python 3.6.0
$ python3 --version
Python 3.6.0
$ unalias python
$ python --version
Python 2.7.6
$ python3 --version
Python 3.6.0
$ pip --version
pip 9.0.1 from /opt/pyenv/versions/3.6.0/lib/python3.6/site-packages (python 3.6)
~/workspace/ $ pip3 --version
pip 9.0.1 from /opt/pyenv/versions/3.6.0/lib/python3.6/site-packages (python 3.6)
$ unalias pip
$ pip --version
pip 1.5.4 from /usr/lib/python2.7/dist-packages (python 2.7)
$ pip3 --version
pip 9.0.1 from /opt/pyenv/versions/3.6.0/lib/python3.6/site-packages (python 3.6)
```