### PR TITLE
ensured c9 exists before running

### DIFF
--- a/update50
+++ b/update50
@@ -172,4 +172,7 @@ else
     C9="/mnt/shared/sbin/c9"
 fi
 
-$C9 exec restart_terminals
+# avoid running when building Docker image
+if [ -x "$C9" ]; then
+    $C9 exec restart_terminals
+fi


### PR DESCRIPTION
Shouldn't be run during image build since no plugins are loaded then.