### PR TITLE
not suggesting anything when no .c files exist

### DIFF
--- a/files/etc/bash_completion.d/make
+++ b/files/etc/bash_completion.d/make
@@ -6,8 +6,17 @@ _make() {
     cur="${COMP_WORDS[COMP_CWORD]}"
     if [[ ${cur} != -* ]]; then
 
+        # back up nullglob setting
+        local glob=$(shopt -p nullglob)
+
+        # no suggestion when no .c files exist
+        shopt -s nullglob
+
         # complete C filenames without the .c extension
         COMPREPLY=( $(compgen -W "$(for f in *.c; do echo ${f%.c}; done)" -- ${cur}) )
+
+        # restore nullglob setting
+        eval "${glob}" &> /dev/null
         return 0
     fi
 }


### PR DESCRIPTION
To avoid suggesting directories and other files when there are no C files in the current directory.