### PR TITLE
servers/check50/rvm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION_FILE := $(FILES_DIR)/etc/version50
 PLUGINS := audioplayer cat debug gist hex info presentation simple statuspage theme
 
 NAME := ide50
-VERSION := 119
+VERSION := 120
 
 define getplugin
 	@echo "\nFetching $(1)..."

--- a/files/etc/profile.d/ide50.sh
+++ b/files/etc/profile.d/ide50.sh
@@ -136,7 +136,7 @@ flask()
             elif echo "$1" | egrep -q "^--with(out)?-threads$"; then
                 threads="$1"
             else
-                options="$options $1"
+                options+=" $1"
             fi
             shift
         done

--- a/files/etc/profile.d/ide50.sh
+++ b/files/etc/profile.d/ide50.sh
@@ -162,7 +162,7 @@ _http_server()
     local cors="--cors"
     local i="-i false"
     local p="-p 8080"
-    local options=""
+    local options="--no-dotfiles"
 
     # override default options
     while test ${#} -gt 0

--- a/files/etc/profile.d/ide50.sh
+++ b/files/etc/profile.d/ide50.sh
@@ -120,9 +120,10 @@ flask()
         fi
 
         # default options
-        host="--host=0.0.0.0"
-        port="--port=8080"
-        threads="--with-threads"
+        local host="--host=0.0.0.0"
+        local port="--port=8080"
+        local threads="--with-threads"
+        local options=""
 
         # override default options
         shift
@@ -135,11 +136,7 @@ flask()
             elif echo "$1" | egrep -q "^--with(out)?-threads$"; then
                 threads="$1"
             else
-                if [ -z "$options" ]; then
-                    options="$1"
-                else
-                    options="$options $1"
-                fi
+                options="$options $1"
             fi
             shift
         done
@@ -160,11 +157,12 @@ flask()
 _http_server()
 {
     # default options
-    a="-a 0.0.0.0"
-    c="-c-1"
-    cors="--cors"
-    i="-i false"
-    p="-p 8080"
+    local a="-a 0.0.0.0"
+    local c="-c-1"
+    local cors="--cors"
+    local i="-i false"
+    local p="-p 8080"
+    local options=""
 
     # override default options
     while test ${#} -gt 0
@@ -188,11 +186,7 @@ _http_server()
             shift
             shift
         else
-            if [ -z "$options" ]; then
-                options="$1"
-            else
-                options+=" $1"
-            fi
+            options+=" $1"
             shift
         fi
     done

--- a/update50
+++ b/update50
@@ -142,7 +142,7 @@ unset PYTHONPATH
 export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
 
 # install python packages
-PYTHON_PACKAGES="check50==2.1.2 \
+PYTHON_PACKAGES="check50==2.1.3 \
     cs50==2.2.0 \
     feedparser \
     Flask \

--- a/update50
+++ b/update50
@@ -164,7 +164,7 @@ PYTHON_PACKAGES="check50==2.1.3 \
 /opt/pyenv/bin/pyenv rehash
 
 # install ruby 2.4.0 and make it default
-rvm install ruby-2.4.0 --default
+rvm install ruby-2.4.0 --default &> /dev/null
 
 echo "Update complete!"
 

--- a/update50
+++ b/update50
@@ -130,7 +130,7 @@ if [ ! -w "$npm_prefix" ]; then
 fi
 
 echo "Installing npm packages..."
-npm install -g http-server
+npm install -g github:indexzero/http-server
 
 echo "Installing Python packages..."
 


### PR DESCRIPTION
```
$ http-server
Starting up http-server, serving ./
Available on:
  http://v120-kzidane.c9users.io:8080
Hit CTRL-C to stop the server
^Chttp-server stopped.
$ http-server -h
usage: http-server [path] [options]

options:
  -p           Port to use [8080]
  -a           Address to use [0.0.0.0]
  -d           Show directory listings [true]
  -i           Display autoIndex [true]
  -g --gzip    Serve gzip files when possible [false]
  -e --ext     Default file extension if none supplied [none]
  -s --silent  Suppress log messages from output
  --cors[=headers]   Enable CORS via the "Access-Control-Allow-Origin" header
                     Optionally provide CORS headers list separated by commas
  -o [path]    Open browser window after starting the server
  -c           Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.
               To disable caching, use -c-1.
  -U --utc     Use UTC time format in log messages.

  -P --proxy   Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com

  -S --ssl     Enable https.
  -C --cert    Path to ssl cert file (default: cert.pem).
  -K --key     Path to ssl key file (default: key.pem).

  -r --robots  Respond to /robots.txt [User-agent: *\nDisallow: /]
  -h --help    Print this list and exit.
$ http-server
Starting up http-server, serving ./
Available on:
  http://v120-kzidane.c9users.io:8080
Hit CTRL-C to stop the server
```