### PR TITLE
specified pgloader version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,20 +55,20 @@ deb: clean Makefile
 		clang-3.8, \
 		dnsutils, \
 		dos2unix, \
-		git (>= 1:2.13.0-0ppa1~ubuntu14.04.1), \
+		git (>= 1:2.13.0), \
 		git-lfs, \
 		gdbserver, \
 		inotify-tools, \
-		libcs50 (>= 8.1.0-0ubuntu1), \
-		libcs50-java (>= 2.0.2-0ubuntu1), \
+		libcs50 (>= 8.1.0), \
+		libcs50-java (>= 2.0.2), \
 		libphp-phpmailer, \
 		libxslt1-dev, \
 		manpages-dev, \
 		ngrok-client, \
 		nodejs, \
 		openjdk-7-jdk, \
-		pgloader (>= 3.4.1+dfsg-1~pgdg14.04+1), \
-		php-cs50 (>= 6.0.0-0ubuntu1), \
+		pgloader (>= 3.4.1), \
+		php-cs50 (>= 6.0.0), \
 		php5-cgi, \
 		php5-curl, \
 		php5-sqlite, \

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ deb: clean Makefile
 		ngrok-client, \
 		nodejs, \
 		openjdk-7-jdk, \
-		pgloader, \
+		pgloader (>= 3.4.1+dfsg-1~pgdg14.04+1), \
 		php-cs50 (>= 6.0.0-0ubuntu1), \
 		php5-cgi, \
 		php5-curl, \


### PR DESCRIPTION
Turns out some workspaces already have an older version of `pgloader` installed which doesn't seem to support Python 3. Specifying a version guarantees >= 3.4.1.