### PR TITLE
no longer setting FLASK_DEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION_FILE := $(FILES_DIR)/etc/version50
 PLUGINS := audioplayer browser cat debug gist hex info presentation simple statuspage theme
 
 NAME := ide50
-VERSION := 131
+VERSION := 132
 
 define getplugin
 	@echo "\nFetching $(1)..."

--- a/files/etc/profile.d/ide50.sh
+++ b/files/etc/profile.d/ide50.sh
@@ -105,7 +105,6 @@ export DEBIAN_FRONTEND=noninteractive
 
 # flask
 export FLASK_APP="application.py"
-export FLASK_DEBUG="1"
 alias flask="/home/ubuntu/.cs50/bin/flask"
 
 # http-server


### PR DESCRIPTION
As planned since Fall 2017 has ended. This way, students have to look in terminal window for (highlighted) tracebacks. Also means interactive web debugger isn't exposed on public apps without students' knowledge.