### PR TITLE
removed shopt as not supported by sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION_FILE := $(FILES_DIR)/etc/version50
 PLUGINS := audioplayer browser cat debug gist hex info presentation simple statuspage theme
 
 NAME := ide50
-VERSION := 137
+VERSION := 138
 
 define getplugin
 	@echo "\nFetching $(1)..."

--- a/files/etc/profile.d/ide50.sh
+++ b/files/etc/profile.d/ide50.sh
@@ -136,6 +136,4 @@ export rvm_project_rvmrc="0"
 
 # history
 # https://www.shellhacks.com/tune-command-line-history-bash/
-shopt -s histappend  # Append Bash Commands to History File
 export PROMPT_COMMAND='history -a'  # Store Bash History Immediately
-shopt -s cmdhist  # Use one command per line


### PR DESCRIPTION
Package maintainer scripts use `sh` so this breaks things when gets sourced. Also these options are set by default in `bash` anyway.